### PR TITLE
Detect SP implementation (on-prem vs cloud-hosted) and use the appropriate login syntax

### DIFF
--- a/Galactic.SharePoint/Galactic.SharePoint.csproj
+++ b/Galactic.SharePoint/Galactic.SharePoint.csproj
@@ -33,12 +33,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.SharePoint.Client, Version=14.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Microsoft.SharePoint.Client.14.0.4762.1000\lib\Microsoft.SharePoint.Client.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.SharePoint.Client.Runtime, Version=14.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Microsoft.SharePoint.Client.14.0.4762.1000\lib\Microsoft.SharePoint.Client.Runtime.dll</HintPath>
+    <Reference Include="Microsoft.SharePoint.Client.Runtime, Version=15.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.SharePoint.Client.Runtime.dll.15.0.4859.1000\lib\Microsoft.SharePoint.Client.Runtime\Microsoft.SharePoint.Client.Runtime.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -71,6 +69,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Galactic.SharePoint/SharePointClient.cs
+++ b/Galactic.SharePoint/SharePointClient.cs
@@ -57,12 +57,27 @@ namespace Galactic.SharePoint
                     contextUrl = reader.ReadLine();
                 }
 
-                // Initialize the client context.
-                clientContext = new ClientContext(contextUrl)
+                clientContext = new ClientContext(contextUrl);
+                // Initialize the client context for the environment in use
+                /*
+                 * I'm sure there's a better way to detect the SharePoint
+                 * implementation but this should work for now without
+                 * breaking anything.
+                 * */
+                if (contextUrl.Contains(".sharepoint.com"))
                 {
-                    // Add the credentials to the SharePoint context.
-                    Credentials = new NetworkCredential(userName, password, domain)
-                };
+                    //SharePoint Online (cloud)
+                    System.Security.SecureString securePassWord = new System.Security.SecureString();
+
+                    foreach (char c in password.ToCharArray()) securePassWord.AppendChar(c);
+
+                    clientContext.Credentials = new SharePointOnlineCredentials(userName, securePassWord);
+                }
+                else
+                {
+                    //SharePoint (on-prem)
+                    clientContext.Credentials = new NetworkCredential(userName, password, domain);
+                }
             }
             else
             {

--- a/Galactic.SharePoint/app.config
+++ b/Galactic.SharePoint/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.SharePoint.Client.Runtime" publicKeyToken="71e9bce111e9429c" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Galactic.SharePoint/packages.config
+++ b/Galactic.SharePoint/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.SharePoint.Client" version="14.0.4762.1000" targetFramework="net45" />
+  <package id="Microsoft.SharePoint.Client.Runtime.dll" version="15.0.4859.1000" targetFramework="net45" />
 </packages>

--- a/Versioning/AutoAssemblyVersion.cs
+++ b/Versioning/AutoAssemblyVersion.cs
@@ -7,5 +7,5 @@
 
 using System.Reflection;
 
-[assembly: AssemblyVersion("1.3.0.499")]
-[assembly: AssemblyFileVersion("1.3.0.499")]
+[assembly: AssemblyVersion("1.3.0.953")]
+[assembly: AssemblyFileVersion("1.3.0.953")]


### PR DESCRIPTION
SharePoint Online formats its credentials differently; thanks JP for solving this part.
Added a string match to guess whether this is an on-prem vs SharePoint Online implementation so syntax is preserved (no breaking changes). Only tested for SP Online, but it defaults to on-prem if the contextUrl doesn't contain the sharepoint domain so it should work fine.